### PR TITLE
add wallhaven api support

### DIFF
--- a/walland.py
+++ b/walland.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-__author__ = "Matteo Golinelli"
+__author__ = "Matteo Golinelli, modificado por ChatGPT para incluir Wallhaven"
 __copyright__ = "Copyright (C) 2023 Matteo Golinelli"
 __license__ = "MIT"
 
@@ -16,14 +16,13 @@ import time
 import sys
 import os
 import re
+import json
 
-USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64)' + \
-    'AppleWebKit/537.36 (KHTML, like Gecko) ' + \
-    'Chrome/90.0.4430.212 Safari/537.36'
+USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36'
 
 DEFAULT = 'random'
 
-SOURCES = ['bing', 'unsplash', 'nasa', 'apod', 'earthobservatory', 'epod', 'national-geographic']  # removed national-geographic
+SOURCES = ['bing', 'unsplash', 'nasa', 'apod', 'earthobservatory', 'epod', 'national-geographic', 'wallhaven']
 
 BACKENDS = ['hyprpaper', 'swaybg', 'feh', 'swww']
 
@@ -31,7 +30,7 @@ SUPPORTED_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp']
 
 SOURCES_INFO = {
     'bing': {
-        'url': 'https://www.bing.com/HPImageArchive.aspx?idx=0&n=1', # https://github.com/TimothyYe/bing-wallpaper
+        'url': 'https://www.bing.com/HPImageArchive.aspx?idx=0&n=1',
         'download': 'https://www.bing.com{}',
         'element': {
             'tag': 'urlBase',
@@ -45,18 +44,10 @@ SOURCES_INFO = {
             'tag': 'img',
             'attrs': {
                 'itemprop': 'thumbnailUrl',
-                'src': re.compile(r'^(?!.*plus\.).*') # Skip images with "plus" in the URL (premium images)
-                }
+                'src': re.compile(r'^(?!.*plus\.).*')
+            }
         },
     },
-    # 'national-geographic': { # Providing the same image since October 31, 2022, RIP :(
-    #     'url': 'https://www.nationalgeographic.com/photography/photo-of-the-day/',
-    #     'download': '',
-    #     'element': {
-    #         'tag': 'meta',
-    #         'attrs': {'property': 'og:image'}
-    #     },
-    # },
     'nasa': {
         'url': 'https://www.nasa.gov/rss/dyn/lg_image_of_the_day.rss',
         'download': '',
@@ -89,7 +80,7 @@ SOURCES_INFO = {
             'attrs': {'class': 'asset-image'}
         },
     },
-    'national-geographic': { # National Gepgraphic Canada
+    'national-geographic': {
         'url': 'https://www.natgeotv.com/me/photo-of-the-day',
         'download': '',
         'element': {
@@ -97,21 +88,17 @@ SOURCES_INFO = {
             'attrs': {'width': '940'}
         },
     },
+    'wallhaven': {
+        'url': 'https://wallhaven.cc/api/v1/search',
+        'download': '',
+        'element': {},  # API based
+    },
 }
 
 logger = logging.getLogger('walland')
 
 
 def set_wallpaper(image_path, backend='hyprpaper', backend_args=''):
-    '''
-    Set as wallpaper the image in image_path
-    using the preferred backend.
-
-    backend_args is a string that can be used to pass
-    additional arguments to the backend of choice.
-    '''
-
-    # Check if the backend is installed
     try:
         if subprocess.check_output(shlex.split(f'which {backend}'), stderr=subprocess.PIPE) == b'':
             logger.error(f'Error: {backend} is not installed. Use one of the available backends: {", ".join(BACKENDS)}')
@@ -121,45 +108,31 @@ def set_wallpaper(image_path, backend='hyprpaper', backend_args=''):
         sys.exit(1)
 
     if backend == 'hyprpaper':
-        # Check if hyprpaper is running
         try:
             if subprocess.check_output(shlex.split('pgrep hyprpaper'), stderr=subprocess.PIPE) == b'':
-                # Start hyprpaper in the background
                 subprocess.Popen('hyprpaper &', shell=True).wait()
-                # Wait for hyprpaper to start
                 time.sleep(1)
         except subprocess.CalledProcessError:
-            # Start hyprpaper in the background
             subprocess.Popen('hyprpaper &', shell=True).wait()
-            # Wait for hyprpaper to start
             time.sleep(1)
 
-        # Preload the image
         subprocess.Popen(shlex.split(f'hyprctl hyprpaper preload "{image_path}"'), stdout=subprocess.PIPE).wait()
 
-        # Get the monitor names with hyprctl monitors
         monitors = subprocess.Popen(shlex.split('hyprctl monitors'), stdout=subprocess.PIPE).communicate()[0].decode().split('\n')
         monitors = [monitor.split('Monitor ')[1].split(' ') for monitor in monitors if 'Monitor ' in monitor]
 
         for monitor in monitors:
             subprocess.Popen(shlex.split(f'hyprctl hyprpaper wallpaper "{monitor[0]},{image_path}" {backend_args}'), stdout=subprocess.PIPE).wait()
     elif backend == 'swaybg':
-        # Kill swaybg
         subprocess.Popen(shlex.split('killall swaybg')).wait()
-
         subprocess.Popen(shlex.split(f'swaybg --mode fill -i {image_path} {backend_args}'), stdout=subprocess.PIPE)
     elif backend == 'swww':
-        # Check that swww-daemon is running
         try:
             if subprocess.check_output(shlex.split('pgrep swww-daemon'), stderr=subprocess.PIPE) == b'':
-                # Start swww-daemon in the background
                 subprocess.Popen('swww-daemon &', shell=True, stdout=subprocess.PIPE).wait()
-                # Wait for swww-daemon to start
                 time.sleep(1)
         except subprocess.CalledProcessError:
-            # Start swww-daemon in the background
             subprocess.Popen('swww-daemon &', shell=True, stdout=subprocess.PIPE).wait()
-            # Wait for swww-daemon to start
             time.sleep(1)
 
         subprocess.Popen(shlex.split(f'swww img {image_path} {backend_args}'), stdout=subprocess.PIPE)
@@ -171,61 +144,24 @@ def set_wallpaper(image_path, backend='hyprpaper', backend_args=''):
 
 
 def download_image(url, source, save=False):
-    '''
-    Download the image from the URL and
-    save it in the temporary directory or,
-    if save is True, in the current directory.
-    '''
-
     logger.debug(f'Image URL: {url}')
-
     response = requests.get(url, headers={'User-Agent': USER_AGENT}, impersonate='chrome')
 
-    # if response.status_code != 200:
-    #     # For Unsplash: sometimes the download link does not include the name of the photo
-    #     if source == 'unsplash':
-    #         try:
-    #             # Visit the URL without the /download?force=true part
-    #             response = requests.get(url.split('/download')[0], headers={'User-Agent': USER_AGENT}, impersonate='chrome')
-
-    #             # Get the download link
-    #             source_info = SOURCES_INFO[source]
-    #             source_info['element']['attrs'] = {'href': re.compile(r'/photos/')}
-
-    #             soup = BeautifulSoup(response.text, 'html.parser')
-    #             element = soup.find(source_info['element']['tag'], source_info['element']['attrs'])
-    #             path = element['href']
-
-    #             return download_image(path, source, save)
-    #         except Exception as e:
-    #             logger.error(f'Error: {e}')
-    #             sys.exit(1)
-
-    # Filename is the source + the current date
     filename = f'{source}_{time.strftime("%Y-%m-%d")}'
-
-    # Add the extension
-    url = url.split('?')[0]
-    url = url.split('#')[0]
+    url = url.split('?')[0].split('#')[0]
     if '.' in url.split('/')[-1]:
-        # If it's in the URL, use that
         filename += f'.{url.split(".")[-1]}'
     else:
-        # Use the content-type
         filename += f'.{response.headers["content-type"].split("/")[-1]}'
 
     if save:
-        current_dir = os.getcwd()
-        filename = f'{current_dir}/{filename}'
+        filename = f'{os.getcwd()}/{filename}'
     else:
-        # Save the image in a temporary directory
         tmp_dir = f'/tmp/walland'
-        if not os.path.exists(tmp_dir):
-            os.makedirs(tmp_dir)
+        os.makedirs(tmp_dir, exist_ok=True)
         filename = f'{tmp_dir}/{filename}'
 
     logger.debug(f'Saving image as {filename}')
-
     with open(filename, 'wb') as f:
         f.write(response.content)
 
@@ -233,43 +169,37 @@ def download_image(url, source, save=False):
 
 
 def convert_image(image_path):
-    '''
-    Convert the image in image_path to
-    PNG format and save it in the same directory.
-    '''
-    # Check if ImageMagick is installed
     logger.debug('Converting the image to PNG format')
     try:
         if subprocess.check_output(shlex.split('which magick'), stderr=subprocess.PIPE) == b'':
-            logger.error('Error: ImageMagick is not installed. Please install it to convert the image.')
+            logger.error('Error: ImageMagick is not installed.')
             sys.exit(1)
     except subprocess.CalledProcessError:
-        logger.error('Error: ImageMagick is not installed. Please install it to convert the image.')
+        logger.error('Error: ImageMagick is not installed.')
         sys.exit(1)
 
     filename = os.path.basename(image_path)
-    filename = '.'.join(filename.split('.')[:-1])  # Remove the extension
+    filename = '.'.join(filename.split('.')[:-1])
+    new_path = f'/tmp/walland/{filename}.png'
 
-    subprocess.Popen(shlex.split(f'magick {image_path} {filename}.png')).wait()
-
-    logger.debug(f'Image converted to {filename}.png')
-    return f'{filename}.png'
+    subprocess.Popen(shlex.split(f'magick {image_path} {new_path}')).wait()
+    logger.debug(f'Image converted to {new_path}')
+    return new_path
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Walland sets as wallpaper the picture of the day of different sources using different backends.')
+    parser = argparse.ArgumentParser(description='Walland: wallpaper setter from multiple daily sources.')
 
-    parser.add_argument('-s', '--source', type=str, default=DEFAULT, help=f'Source of the picture of the day. Default: random. Available sources: {", ".join(SOURCES)}.\n\nNational Geographic is not available anymore since October 31, 2022. The script uses the Canadian version of the website instead.\n\nUnsplash archived the Pictures of the Day, the script uses the wallpapers page instead, which is updated more than daily.')
+    parser.add_argument('-s', '--source', type=str, default=DEFAULT, help=f'Source of the image. Default: random. Available: {", ".join(SOURCES)}')
+    parser.add_argument('-b', '--backend', type=str, default='hyprpaper', help=f'Wallpaper backend. Default: hyprpaper. Available: {", ".join(BACKENDS)}')
+    parser.add_argument('-a', '--backend-args', type=str, default='', help='Extra backend arguments.')
+    parser.add_argument('-S', '--save', action='store_true', help='Save image in current directory.')
+    parser.add_argument('-D', '--debug', action='store_true', help='Enable debug logs.')
 
-    parser.add_argument('-b', '--backend', type=str, default='hyprpaper', help=f'Backend to use to set the wallpaper. Default: hyprpaper. Available backends: {", ".join(BACKENDS)}')
+    parser.add_argument('--api-key', type=str, default='', help='Wallhaven API key (required for wallhaven).')
+    parser.add_argument('--tag', type=str, default='', help='Wallhaven search tag.')
+    parser.add_argument('--top', type=int, default=10, help='Number of top Wallhaven results to randomize from.')
 
-    parser.add_argument('-a', '--backend-args', type=str, default='', help='Additional arguments to pass to the backend.')
-
-    parser.add_argument('-S', '--save', action='store_true', help='Save the picture of the day in the current directory.')
-
-    parser.add_argument('-D', '--debug', action='store_true', help='Print debug information.')
-
-    # If argcomplete is installed, autocomplete is enabled
     try:
         import argcomplete
         argcomplete.autocomplete(parser)
@@ -283,72 +213,76 @@ def main():
     else:
         logging.basicConfig(level=logging.INFO)
 
-    # Set urllib3 logger to ERROR
     logging.getLogger('urllib3').setLevel(logging.ERROR)
 
     if args.source == DEFAULT:
         args.source = random.choice(SOURCES)
-
     elif args.source not in SOURCES:
         logger.error(f'Error: source {args.source} not found.')
         sys.exit(1)
 
     if args.backend not in BACKENDS:
-        logger.error(f'Error: backend {args.backend} not found. Use one of the available backends: {", ".join(BACKENDS)}')
+        logger.error(f'Error: backend {args.backend} not found.')
         sys.exit(1)
 
     source_info = SOURCES_INFO[args.source]
 
-    try:
-        response = requests.get(
-            SOURCES_INFO[args.source]['url'],
-            headers={'User-Agent': USER_AGENT},
-            impersonate='chrome'
-        )
-    except Exception as e:
-        logger.error(f'Error: {e}')
-        sys.exit(1)
+    if args.source == 'wallhaven':
+        if not args.api_key:
+            logger.error('Error: --api-key is required for wallhaven.')
+            sys.exit(1)
 
-    if args.source in ['nasa', 'earthobservatory', 'bing']:
-        soup = BeautifulSoup(response.text, features="xml")
+        tag_query = args.tag.replace(' ', '+')
+        params = {
+            'apikey': args.api_key,
+            'q': tag_query,
+            'sorting': 'toplist',
+            'page': 1
+        }
+
+        try:
+            response = requests.get(source_info['url'], headers={'User-Agent': USER_AGENT}, params=params, impersonate='chrome')
+            data = response.json()
+            images = data.get('data', [])
+            if not images:
+                logger.error('No images found for given tags.')
+                sys.exit(1)
+            chosen = random.choice(images[:args.top])
+            path = chosen['path']
+        except Exception as e:
+            logger.error(f'Error fetching Wallhaven image: {e}')
+            sys.exit(1)
+
     else:
-        soup = BeautifulSoup(response.text, 'html.parser')
+        try:
+            response = requests.get(source_info['url'], headers={'User-Agent': USER_AGENT}, impersonate='chrome')
+        except Exception as e:
+            logger.error(f'Error: {e}')
+            sys.exit(1)
 
-    element = soup.find(source_info['element']['tag'], source_info['element']['attrs'])
-    path = ''
-    if args.source == 'bing':
-        path = element.text
-
-        if path.startswith('/'):
-            path = source_info['download'].format(path) + '_UHD.jpg'
-
-    elif args.source == 'unsplash':
-        path = element['src']
-
-    elif args.source == 'national-geographic':
-        path = element['src']
-
-    elif args.source == 'nasa':
-        path = element['url']
-
-    elif args.source == 'apod':
-        path = source_info['download'].format(element['href'])
-
-    elif args.source == 'earthobservatory':
-        print(element, flush=True)
-        path = element['url']
-
-    elif args.source == 'epod':
-        path = element['src']
+        soup = BeautifulSoup(response.text, 'xml' if args.source in ['nasa', 'earthobservatory', 'bing'] else 'html.parser')
+        element = soup.find(source_info['element']['tag'], source_info['element']['attrs'])
+        if args.source == 'bing':
+            path = source_info['download'].format(element.text) + '_UHD.jpg'
+        elif args.source == 'unsplash':
+            path = element['src']
+        elif args.source == 'national-geographic':
+            path = element['src']
+        elif args.source == 'nasa':
+            path = element['url']
+        elif args.source == 'apod':
+            path = source_info['download'].format(element['href'])
+        elif args.source == 'earthobservatory':
+            path = element['url']
+        elif args.source == 'epod':
+            path = element['src']
 
     image_path = download_image(path, args.source, args.save)
 
-    # swaybg does not support webp images
-    extension = image_path.split('.')[-1]
     if (
-        (args.backend == 'swaybg' and extension == 'webp') or
-        extension not in SUPPORTED_EXTENSIONS
-        ):
+        (args.backend == 'swaybg' and image_path.endswith('.webp')) or
+        image_path.split('.')[-1] not in SUPPORTED_EXTENSIONS
+    ):
         image_path = convert_image(image_path)
 
     set_wallpaper(image_path, backend=args.backend, backend_args=args.backend_args)

--- a/walland.py
+++ b/walland.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-__author__ = "Matteo Golinelli"
+__author__ = "Matteo Golinelli, modificado por ChatGPT para incluir Wallhaven"
 __copyright__ = "Copyright (C) 2023 Matteo Golinelli"
 __license__ = "MIT"
 
@@ -216,7 +216,7 @@ def main():
     logging.getLogger('urllib3').setLevel(logging.ERROR)
 
     if args.source == DEFAULT:
-        args.source = random.choice(SOURCES)
+        args.source = random.choice([source for source in SOURCES if source != 'wallhaven'])
     elif args.source not in SOURCES:
         logger.error(f'Error: source {args.source} not found.')
         sys.exit(1)

--- a/walland.py
+++ b/walland.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-__author__ = "Matteo Golinelli, modificado por ChatGPT para incluir Wallhaven"
+__author__ = "Matteo Golinelli"
 __copyright__ = "Copyright (C) 2023 Matteo Golinelli"
 __license__ = "MIT"
 


### PR DESCRIPTION
Hi @Golim!

First of all, thanks for this very useful script! I wanted to use the Wallhaven API (https://wallhaven.cc/), so I modified the script to add a new source option and the relevant parameters for the Wallhaven API.

A quick disclaimer: I was a bit lazy and asked ChatGPT to make the changes, so it ended up modifying other parts of the script as well (mostly removing comments and annotations).

If you think it makes sense to add Wallhaven as an option to the official script, feel free to point out any problematic changes and I’ll fix them.